### PR TITLE
Specify (using menhir 2.0).

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.0)
 (name absolute)
-(using menhir 1.0)
+(using menhir 2.0)


### PR DESCRIPTION
This causes Dune to pass --infer to Menhir.
This allows working around a type-checker bug in OCaml 4.07-4.10.