### PR TITLE
Truefalseconstraints

### DIFF
--- a/lib/domains/boolean/boolean.ml
+++ b/lib/domains/boolean/boolean.ml
@@ -22,6 +22,8 @@ module Make (Abs : Numeric) : Domain = struct
     | And (b1, b2) -> sat i b1 && sat i b2
     | Or (b1, b2) -> sat i b1 || sat i b2
     | Not b -> not (sat i b)
+    | True -> true
+    | False -> false
 
   (* filter on boolean formulae. It also computes a simplified boolean formulae
      e.g: - false || c <=> c - true && c <=> c *)
@@ -54,6 +56,8 @@ module Make (Abs : Numeric) : Domain = struct
         | _ -> failwith "pruned" )
       | _ -> failwith "pruned" )
     | Not _ -> assert false
+    | True -> Sat
+    | False -> Unsat
 
   (* filter on boolean formulae. It also computes a simplified boolean formulae
      e.g: - false || c <=> c - true && c <=> c *)
@@ -90,9 +94,12 @@ module Make (Abs : Numeric) : Domain = struct
         | _ -> failwith "pruned" )
       | _ -> failwith "pruned" )
     | Not _ -> assert false
+    | True -> Sat
+    | False -> Unsat
 
   let rec is_representable = function
     | And (a, b) -> Kleene.and_ (is_representable a) (is_representable b)
     | Cmp c -> Abs.is_representable c
+    | True | False -> Kleene.True
     | _ -> Kleene.False
 end

--- a/lib/domains/boolean/uniontree.ml
+++ b/lib/domains/boolean/uniontree.ml
@@ -27,12 +27,17 @@ module Make (D : Numeric) : Domain = struct
     | And (b1, b2) -> sat i b1 && sat i b2
     | Or (b1, b2) -> sat i b1 || sat i b2
     | Not b -> not (sat i b)
+    | True -> true
+    | False -> false
 
-  let rec is_representable = function
-    | Constraint.And (a, b) | Or (a, b) ->
+  let rec is_representable =
+    let open Constraint in
+    function
+    | And (a, b) | Or (a, b) ->
         Kleene.and_ (is_representable a) (is_representable b)
-    | Constraint.Not e -> is_representable e
-    | Constraint.Cmp c -> D.is_representable c
+    | Not e -> is_representable e
+    | Cmp c -> D.is_representable c
+    | True | False -> Kleene.True
 
   let eval = function
     | Leaf n -> D.eval n
@@ -186,6 +191,8 @@ module Make (D : Numeric) : Domain = struct
           | Pruned _ -> failwith "" )
         | Pruned _ -> failwith "" )
       | Not _ -> assert false
+      | True -> Sat
+      | False -> Unsat
     in
     loop n c
 
@@ -236,6 +243,8 @@ module Make (D : Numeric) : Domain = struct
           | Pruned _ -> failwith "" )
         | Pruned _ -> failwith "" )
       | Not _ -> assert false
+      | True -> Sat
+      | False -> Unsat
     in
     loop n c
 

--- a/lib/intervals/filter.ml
+++ b/lib/intervals/filter.ml
@@ -24,16 +24,16 @@ module Make (I : Itv_sig.ITV_EVAL) = struct
   let filter_mul (i1 : t) (i2 : t) (r : t) : (t * t) option =
     Tools.merge_bot
       ( if contains_float r 0. && contains_float i2 0. then Some i1
-      else Option.bind (div r i2) (meet_opt i1) )
+        else Option.bind (div r i2) (meet_opt i1) )
       ( if contains_float r 0. && contains_float i1 0. then Some i2
-      else Option.bind (div r i1) (meet_opt i2) )
+        else Option.bind (div r i1) (meet_opt i2) )
 
   (* r = i1/i2 => i1 = i2*r /\ (i2 = i1/r \/ i1=r=0) *)
   let filter_div (i1 : t) (i2 : t) (r : t) : (t * t) option =
     Tools.merge_bot
       (meet_opt i1 (mul i2 r))
       ( if contains_float r 0. && contains_float i1 0. then Some i2
-      else Option.bind (div i1 r) (meet_opt i2) )
+        else Option.bind (div i1 r) (meet_opt i2) )
 
   (* r = sqrt i => i = r*r or i < 0 *)
   let filter_sqrt (i : t) (r : t) : t option =
@@ -77,6 +77,7 @@ module Make (I : Itv_sig.ITV_EVAL) = struct
     | "sqrt" -> arity_1 filter_sqrt
     | "exp" -> arity_1 filter_exp
     | "ln" -> arity_1 filter_ln
+    | "abs" -> arity_1 filter_abs
     | "max" -> arity_2 filter_max
     | "min" -> arity_2 filter_min
     | s -> failwith (Format.sprintf "unknown filter function : %s" s)

--- a/lib/intervals/newitv.ml
+++ b/lib/intervals/newitv.ml
@@ -173,7 +173,7 @@ module Eval (B : BOUND) = struct
     Constraint.(
       And
         ( Cmp (v, (match kl with Strict -> GT | Large -> GEQ), l_cst)
-        , Cmp (v, (match kh with Strict -> LT | Large -> LEQ), h_cst) ))
+        , Cmp (v, (match kh with Strict -> LT | Large -> LEQ), h_cst) ) )
 
   (************************************************************************)
   (* SET-THEORETIC *)
@@ -357,7 +357,7 @@ module Eval (B : BOUND) = struct
       meet_opt x positive
       |> Option.map (fun x ->
              let pos_part = mon_incr f_down_up x in
-             join pos_part (neg pos_part))
+             join pos_part (neg pos_part) )
     in
     match i with
     | 1 -> Some itv
@@ -436,6 +436,7 @@ module Eval (B : BOUND) = struct
     | "exp" -> arity_1 exp
     | "ln" -> arity_1_bot ln
     | "log" -> arity_1_bot log
+    | "abs" -> arity_1 abs
     (* min max *)
     | "max" -> arity_2 max
     | "min" -> arity_2 min

--- a/lib/lang/constraint.mli
+++ b/lib/lang/constraint.mli
@@ -13,6 +13,8 @@ type 'a boolean =
   | And of 'a boolean * 'a boolean
   | Or of 'a boolean * 'a boolean
   | Not of 'a boolean
+  | True
+  | False
 
 (** type for constraints *)
 type t = comparison boolean
@@ -42,6 +44,10 @@ val neq : Expr.t -> Expr.t -> t
 (** e1 <> e2 *)
 
 (** {2 Boolean formulae}*)
+
+val true_ : t
+
+val false_ : t
 
 val and_ : t -> t -> t
 (** b1 && b2 *)

--- a/lib/lang/expr.ml
+++ b/lib/lang/expr.ml
@@ -50,6 +50,10 @@ let pow e1 e2 = Binary (POW, e1, e2)
 
 let square expr = Binary (POW, expr, two)
 
+let funcall f args = Funcall (f, args)
+
+let abs x = Funcall ("abs", [x])
+
 let rec has_variable = function
   | Funcall (_, args) -> List.exists has_variable args
   | Neg e -> has_variable e

--- a/lib/lang/expr.mli
+++ b/lib/lang/expr.mli
@@ -74,6 +74,13 @@ val pow : t -> t -> t
 val square : t -> t
 (** given an expression [e] builds the expresspion for [e*e]*)
 
+val funcall : string -> t list -> t
+(** given an function name [f] and a list of arguments [a1,...,an] builds the
+    function call [f(a1,...,an]*)
+
+val abs : t -> t
+(** given an expression [e] builds the expresspion for [abs(e)]*)
+
 (** {1 Predicates}*)
 
 val has_variable : t -> bool

--- a/lib/lang/syntax.ml
+++ b/lib/lang/syntax.ml
@@ -81,6 +81,7 @@ let rec get_vars =
   | Cmp (_, s) -> s
   | Not c -> get_vars c
   | Or (c1, c2) | And (c1, c2) -> VSet.union (get_vars c1) (get_vars c2)
+  | _ -> VSet.empty
 
 let rec deannot_constr =
   let open Constraint in
@@ -89,6 +90,8 @@ let rec deannot_constr =
   | Not c -> Not (deannot_constr c)
   | Or (c1, c2) -> Or (deannot_constr c1, deannot_constr c2)
   | And (c1, c2) -> And (deannot_constr c1, deannot_constr c2)
+  | True -> True
+  | False -> False
 
 let build c =
   let v = List.fold_left VSet.union VSet.empty (List.rev_map get_vars c) in


### PR DESCRIPTION
This PR adds true and false litterals to the constraint language. They don't change expressivity but make the definition of CSPs easier. 

It also adds some minor fix regarding the handling of function calls